### PR TITLE
feat(run): adicionar run.py

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,11 @@ O primeiro passo é clonar o repositório do projeto para o seu ambiente local.
    ```sh
    uvicorn src.main:app --reload
    ```
+   Ou execute o camando
+
+   ```sh
+   python run.py
+   ```
 
 4. Acesse a Aplicação
 - O FastAPI está disponível em: [http://localhost:8000](http://localhost:8000)

--- a/run.py
+++ b/run.py
@@ -1,0 +1,9 @@
+import uvicorn
+
+if __name__ == "__main__":
+    uvicorn.run(
+        "src.main:app",
+        host="127.0.0.1",
+        port=8000,
+        reload=True
+    )


### PR DESCRIPTION
Adiciona run.py no root para executar a aplicação com `python run.py` sem precisar do comando completo do uvicorn.